### PR TITLE
Node dead code

### DIFF
--- a/src/encodings/base64.js
+++ b/src/encodings/base64.js
@@ -59,8 +59,8 @@ ByteBuffer.fromBase64 = function(str, littleEndian) {
         bb.view[i++] = b;
     });
     bb.limit = i;
-    //? }
     return bb;
+    //? }
 };
 
 /**

--- a/src/encodings/binary.js
+++ b/src/encodings/binary.js
@@ -67,8 +67,8 @@ ByteBuffer.fromBinary = function(str, littleEndian) {
         bb.view[i++] = charCode;
     }
     bb.limit = k;
-    //? }
     return bb;
+    //? }
 };
 
 //? }


### PR DESCRIPTION
When built for node, these two methods result in a second redundant return statement.

Error captured by coverity static analysis tool.